### PR TITLE
Fix ClientMappers

### DIFF
--- a/src/Elcamino.IdentityServer4.AzureTableStorage/Mappers/ClientMappers.cs
+++ b/src/Elcamino.IdentityServer4.AzureTableStorage/Mappers/ClientMappers.cs
@@ -21,7 +21,10 @@ namespace ElCamino.IdentityServer4.AzureStorage.Mappers
 
                 cfg.CreateMap<Entities.Client, Models.Client>()
                     .ForMember(dest => dest.ProtocolType, opt => opt.Condition(srs => srs != null))
-                    .ReverseMap();
+                    .ReverseMap()
+                    .ForMember(x => x.AllowedIdentityTokenSigningAlgorithms, opts => opts.ConvertUsing(AllowedSigningAlgorithmsConverter.Converter, x => x.AllowedIdentityTokenSigningAlgorithms))
+                    .ReverseMap()
+                    .ForMember(x => x.AllowedIdentityTokenSigningAlgorithms, opts => opts.ConvertUsing(AllowedSigningAlgorithmsConverter.Converter, x => x.AllowedIdentityTokenSigningAlgorithms));
 
                 cfg.CreateMap<Entities.ClientCorsOrigin, string>()
                     .ConstructUsing(src => src.Origin)


### PR DESCRIPTION
The `AllowedIdentityTokenSigningAlgorithms` Property is type of `ICollection<string>` in IdentityServer4. Without this fix the property turns into a string of the type and not a string containg the type.

Here is a before and after (JSON)

Before:

```json
{
  ...
  "AllowedIdentityTokenSigningAlgorithms": "System.Collections.Generic.HashSet`1[System.String]",
  ...
}
```

After:

```json
{
  ...
  "AllowedIdentityTokenSigningAlgorithms": "item1,item2",
  ...
}
```